### PR TITLE
fixed path bug in "mix" function

### DIFF
--- a/theme/functions.php
+++ b/theme/functions.php
@@ -207,9 +207,6 @@ class Timberland extends Site
     public function mix($path, $manifestDirectory = '')
     {
         static $manifest;
-        if ($manifestDirectory && strpos($manifestDirectory, '/') !== 0) {
-            $manifestDirectory = "/{$manifestDirectory}";
-        }
 
         if (! $manifest) {
             if (! file_exists($manifestPath = $manifestDirectory.'/mix-manifest.json')) {


### PR DESCRIPTION
For example; The variable "$manifestDirectory" starts with an expression like "C:\xampp\.." and if "/" is added to the first character, the result is ""/C:\xampp\..", so the manifest file path cannot be found. To fix the error, the relevant condition has been removed. An example case : #20 

The "get_template_directory()" function on line 83 correctly returns the path. I think there is no need to recheck with a separate condition.

After the condition was removed, it was tested on Windows and Centos 9 operating systems and no problems were found.

